### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/855/421166855.geojson
+++ b/data/421/166/855/421166855.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459008705,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"edf02d16a875091219fe41ea68fe7d48",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421166855,
-    "wof:lastmodified":1566648820,
+    "wof:lastmodified":1582317844,
     "wof:name":"Koungheul",
     "wof:parent_id":85676989,
     "wof:placetype":"county",

--- a/data/421/176/669/421176669.geojson
+++ b/data/421/176/669/421176669.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009115,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17a88dde29be4f84520aaa413cd4bd7b",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421176669,
-    "wof:lastmodified":1566648831,
+    "wof:lastmodified":1582317845,
     "wof:name":"Mbacke",
     "wof:parent_id":85677001,
     "wof:placetype":"county",

--- a/data/421/181/825/421181825.geojson
+++ b/data/421/181/825/421181825.geojson
@@ -185,6 +185,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009308,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66ab4dd92d57f52cba120b220b3cf555",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421181825,
-    "wof:lastmodified":1566648826,
+    "wof:lastmodified":1582317845,
     "wof:name":"Kaolack",
     "wof:parent_id":85677011,
     "wof:placetype":"county",

--- a/data/421/185/475/421185475.geojson
+++ b/data/421/185/475/421185475.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009444,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"231e6dd57180a0deca74d8917a7fd301",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421185475,
-    "wof:lastmodified":1566648832,
+    "wof:lastmodified":1582317845,
     "wof:name":"Mbour",
     "wof:parent_id":85677025,
     "wof:placetype":"county",

--- a/data/421/187/935/421187935.geojson
+++ b/data/421/187/935/421187935.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0afbc6be3d7660f88b46496fb2f9d6d8",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421187935,
-    "wof:lastmodified":1566648825,
+    "wof:lastmodified":1582317844,
     "wof:name":"Fatick",
     "wof:parent_id":85677007,
     "wof:placetype":"county",

--- a/data/421/187/963/421187963.geojson
+++ b/data/421/187/963/421187963.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"02d5535909b4776859cb27f081a36074",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421187963,
-    "wof:lastmodified":1566648824,
+    "wof:lastmodified":1582317844,
     "wof:name":"Rufisque",
     "wof:parent_id":85676997,
     "wof:placetype":"county",

--- a/data/421/187/965/421187965.geojson
+++ b/data/421/187/965/421187965.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a34e15241f07d9c380e6c133d45b815",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":421187965,
-    "wof:lastmodified":1537303681,
+    "wof:lastmodified":1582317844,
     "wof:name":"Dakar",
     "wof:parent_id":85676997,
     "wof:placetype":"county",

--- a/data/421/187/969/421187969.geojson
+++ b/data/421/187/969/421187969.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee86f393bd381813322c339ce7414e24",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421187969,
-    "wof:lastmodified":1566648825,
+    "wof:lastmodified":1582317845,
     "wof:name":"Foundiougne",
     "wof:parent_id":85677007,
     "wof:placetype":"county",

--- a/data/421/187/971/421187971.geojson
+++ b/data/421/187/971/421187971.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2d66c30e14e75372e4a7a3884862488",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421187971,
-    "wof:lastmodified":1566648824,
+    "wof:lastmodified":1582317844,
     "wof:name":"Oussouye",
     "wof:parent_id":85677033,
     "wof:placetype":"county",

--- a/data/421/187/973/421187973.geojson
+++ b/data/421/187/973/421187973.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e4feb3bc2b96763ee9af620b5db988fe",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421187973,
-    "wof:lastmodified":1566648825,
+    "wof:lastmodified":1582317845,
     "wof:name":"Dagana",
     "wof:parent_id":85676993,
     "wof:placetype":"county",

--- a/data/421/191/947/421191947.geojson
+++ b/data/421/191/947/421191947.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009715,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f93c283eee3524ac4458b81fa15a283",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421191947,
-    "wof:lastmodified":1566648827,
+    "wof:lastmodified":1582317845,
     "wof:name":"Tambacounda",
     "wof:parent_id":85677035,
     "wof:placetype":"county",

--- a/data/421/193/105/421193105.geojson
+++ b/data/421/193/105/421193105.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009760,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9825b1131e2ec1bfab137222da6f1f8e",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421193105,
-    "wof:lastmodified":1566648821,
+    "wof:lastmodified":1582317844,
     "wof:name":"Pikine",
     "wof:parent_id":85676997,
     "wof:placetype":"county",

--- a/data/421/199/619/421199619.geojson
+++ b/data/421/199/619/421199619.geojson
@@ -602,6 +602,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459009995,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a34e15241f07d9c380e6c133d45b815",
     "wof:hierarchy":[
         {
@@ -613,7 +616,7 @@
         }
     ],
     "wof:id":421199619,
-    "wof:lastmodified":1566648828,
+    "wof:lastmodified":1582317845,
     "wof:name":"Dakar",
     "wof:parent_id":421187965,
     "wof:placetype":"locality",

--- a/data/421/203/235/421203235.geojson
+++ b/data/421/203/235/421203235.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35ca5de8a807060174d3299e19d24a36",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421203235,
-    "wof:lastmodified":1566648822,
+    "wof:lastmodified":1582317844,
     "wof:name":"Bignona",
     "wof:parent_id":85677033,
     "wof:placetype":"county",

--- a/data/421/203/237/421203237.geojson
+++ b/data/421/203/237/421203237.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f4ff9d8c79d0b48d3a9797c8626f3c2",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421203237,
-    "wof:lastmodified":1566648823,
+    "wof:lastmodified":1582317844,
     "wof:name":"Ziguinchor",
     "wof:parent_id":85677033,
     "wof:placetype":"county",

--- a/data/421/203/459/421203459.geojson
+++ b/data/421/203/459/421203459.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"SN",
     "wof:created":1459010152,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3698dd3b9e770af152b69d85768b987b",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421203459,
-    "wof:lastmodified":1566648823,
+    "wof:lastmodified":1582317844,
     "wof:name":"Thies",
     "wof:parent_id":85677025,
     "wof:placetype":"county",

--- a/data/856/323/65/85632365.geojson
+++ b/data/856/323/65/85632365.geojson
@@ -948,6 +948,11 @@
     },
     "wof:country":"SN",
     "wof:country_alpha3":"SEN",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"84a385691ebed314661e526b5b99890f",
     "wof:hierarchy":[
         {
@@ -964,7 +969,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648182,
+    "wof:lastmodified":1582317833,
     "wof:name":"Senegal",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/769/79/85676979.geojson
+++ b/data/856/769/79/85676979.geojson
@@ -222,6 +222,9 @@
         "wk:page":"S\u00e9dhiou Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"73cd0484c3b337160785cf4a8573f429",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648188,
+    "wof:lastmodified":1582317836,
     "wof:name":"Sedhiou",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/769/83/85676983.geojson
+++ b/data/856/769/83/85676983.geojson
@@ -232,6 +232,9 @@
         "wk:page":"K\u00e9dougou Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60d16b32b6aab9a4beec7adf444eaf9f",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648188,
+    "wof:lastmodified":1582317836,
     "wof:name":"Kedougou",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/769/89/85676989.geojson
+++ b/data/856/769/89/85676989.geojson
@@ -224,6 +224,9 @@
         "wk:page":"Kaffrine Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0edda9279e41330d572692d2297ea946",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648187,
+    "wof:lastmodified":1582317835,
     "wof:name":"Kaffrine",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/769/93/85676993.geojson
+++ b/data/856/769/93/85676993.geojson
@@ -223,6 +223,9 @@
         "wk:page":"Saint-Louis Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"810d75f72a9500ab7c90584bf58ffefe",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648187,
+    "wof:lastmodified":1582317835,
     "wof:name":"Saint-Louis",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/769/97/85676997.geojson
+++ b/data/856/769/97/85676997.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Dakar Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3881955685ba81c19c92b25a47ac1a90",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648187,
+    "wof:lastmodified":1582317835,
     "wof:name":"Dakar",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/01/85677001.geojson
+++ b/data/856/770/01/85677001.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Diourbel Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95c8e5d0c7ed2d41e729c66f12ea92cc",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648186,
+    "wof:lastmodified":1582317835,
     "wof:name":"Diourbel",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/07/85677007.geojson
+++ b/data/856/770/07/85677007.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Fatick Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71a93284d27330b56dcb0d5862bf232e",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648186,
+    "wof:lastmodified":1582317835,
     "wof:name":"Fatick",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/11/85677011.geojson
+++ b/data/856/770/11/85677011.geojson
@@ -219,6 +219,9 @@
         "wk:page":"Kaolack Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69fafa1105395266a72ac773e7c920ec",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648185,
+    "wof:lastmodified":1582317835,
     "wof:name":"Kaolack",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/15/85677015.geojson
+++ b/data/856/770/15/85677015.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Louga Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f80a223342436d6d400fa9da4d963b0",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648186,
+    "wof:lastmodified":1582317835,
     "wof:name":"Louga",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/19/85677019.geojson
+++ b/data/856/770/19/85677019.geojson
@@ -222,6 +222,9 @@
         "wk:page":"Matam Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fda323280b2f7206b748acd98c63cd63",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648186,
+    "wof:lastmodified":1582317835,
     "wof:name":"Matam",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/25/85677025.geojson
+++ b/data/856/770/25/85677025.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Thi\u00e8s Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f1aaaf4e5763f072f0e9a6b567469b8",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648187,
+    "wof:lastmodified":1582317835,
     "wof:name":"Thies",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/27/85677027.geojson
+++ b/data/856/770/27/85677027.geojson
@@ -234,6 +234,9 @@
         "wk:page":"Kolda Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e8aa426a872243779149ad1a12adefe",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648185,
+    "wof:lastmodified":1582317835,
     "wof:name":"Kolda",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/33/85677033.geojson
+++ b/data/856/770/33/85677033.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Ziguinchor Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"791a74d3f66e640684f1f6a07b007397",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648184,
+    "wof:lastmodified":1582317834,
     "wof:name":"Ziguinchor",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/35/85677035.geojson
+++ b/data/856/770/35/85677035.geojson
@@ -226,6 +226,9 @@
         "wk:page":"Tambacounda Region"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b4fcf8f9bce768be7e8eac6855885b1",
     "wof:hierarchy":[
         {
@@ -243,7 +246,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1566648184,
+    "wof:lastmodified":1582317834,
     "wof:name":"Tambacounda",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/858/022/15/85802215.geojson
+++ b/data/858/022/15/85802215.geojson
@@ -93,6 +93,9 @@
         "qs_pg:id":423492
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"703b881e4fccc6f5670baf0ff0231493",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566648189,
+    "wof:lastmodified":1582317836,
     "wof:name":"Arafat I",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/19/85802219.geojson
+++ b/data/858/022/19/85802219.geojson
@@ -88,6 +88,9 @@
         "qs_pg:id":496844
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de06faa7457e051d5536a15241aecdc8",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566648189,
+    "wof:lastmodified":1582317836,
     "wof:name":"Bel-Air",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/23/85802223.geojson
+++ b/data/858/022/23/85802223.geojson
@@ -75,6 +75,9 @@
         "qs:id":222665
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15e50dafa9db9f8128755df8cce0ac3c",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379462,
+    "wof:lastmodified":1582317836,
     "wof:name":"Fann",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/27/85802227.geojson
+++ b/data/858/022/27/85802227.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":222666
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d593b2112135560f08438a45575577a",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566648189,
+    "wof:lastmodified":1582317836,
     "wof:name":"Fass",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/33/85802233.geojson
+++ b/data/858/022/33/85802233.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Grand Dakar"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8218fe93ee9507d0de3e39217f902e0d",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566648188,
+    "wof:lastmodified":1582317836,
     "wof:name":"Grand Dakar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/35/85802235.geojson
+++ b/data/858/022/35/85802235.geojson
@@ -113,6 +113,9 @@
         "wk:page":"M\u00e9dina, Dakar"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1759407a83e980fbff5d5312a5f678b7",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566648188,
+    "wof:lastmodified":1582317836,
     "wof:name":"M\u00e9dina",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/39/85802239.geojson
+++ b/data/858/022/39/85802239.geojson
@@ -76,6 +76,9 @@
         "qs:id":1175249
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb972f790c9ff25fb1f28e168c3e2b50",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379462,
+    "wof:lastmodified":1582317836,
     "wof:name":"Point E",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/43/85802243.geojson
+++ b/data/858/022/43/85802243.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1116541
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24d4f47bf271434cdd7501c9dada3f95",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566648189,
+    "wof:lastmodified":1582317836,
     "wof:name":"Soumb\u00e9dioune",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/49/85802249.geojson
+++ b/data/858/022/49/85802249.geojson
@@ -76,6 +76,9 @@
         "wk:page":"Hann, Senegal"
     },
     "wof:country":"SN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"459d8fac558cce4421266a3f1e077b62",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379462,
+    "wof:lastmodified":1582317836,
     "wof:name":"Yararh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/424/907/890424907.geojson
+++ b/data/890/424/907/890424907.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"SN",
     "wof:created":1469051568,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86b528b4bec9c903591bd7c31efe6c50",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890424907,
-    "wof:lastmodified":1566648832,
+    "wof:lastmodified":1582317845,
     "wof:name":"Matam",
     "wof:parent_id":85677019,
     "wof:placetype":"county",

--- a/data/890/440/853/890440853.geojson
+++ b/data/890/440/853/890440853.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"SN",
     "wof:created":1469052299,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8885d49c96ed69d03b584c53dc96c8de",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":890440853,
-    "wof:lastmodified":1566648832,
+    "wof:lastmodified":1582317845,
     "wof:name":"Guediewaye",
     "wof:parent_id":85676997,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.