### PR TITLE
Update properties of megacities

### DIFF
--- a/data/421/199/619/421199619.geojson
+++ b/data/421/199/619/421199619.geojson
@@ -601,6 +601,7 @@
         "gn:id":2253354,
         "gp:id":1411986,
         "loc:id":"n79108879",
+        "ne:id":1159151513,
         "qs_pg:id":1220982,
         "wd:id":"Q3718",
         "wk:page":"Dakar"
@@ -621,7 +622,8 @@
         }
     ],
     "wof:id":421199619,
-    "wof:lastmodified":1607390900,
+    "wof:lastmodified":1608688189,
+    "wof:megacity":1,
     "wof:name":"Dakar",
     "wof:parent_id":421187965,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary