### PR TITLE
sn concordances, placetype local, and more

### DIFF
--- a/data/110/869/145/5/1108691455.geojson
+++ b/data/110/869/145/5/1108691455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159465,
-    "geom:area_square_m":1924316469.67719,
+    "geom:area_square_m":1924316423.230402,
     "geom:bbox":"-13.121611,12.368651,-12.388322,12.839699",
     "geom:latitude":12.60139,
     "geom:longitude":-12.79787,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KG.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311862,
-    "wof:geomhash":"d40cd3b0f5133551f74372cabe3712f7",
+    "wof:geomhash":"ff455d655a625c6ea6645517898781e9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691455,
-    "wof:lastmodified":1627522783,
+    "wof:lastmodified":1695886477,
     "wof:name":"Salemata",
     "wof:parent_id":85676983,
     "wof:placetype":"county",

--- a/data/110/869/145/7/1108691457.geojson
+++ b/data/110/869/145/7/1108691457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144419,
-    "geom:area_square_m":1742529122.691894,
+    "geom:area_square_m":1742529122.691892,
     "geom:bbox":"-15.9686904949,12.4249053689,-15.1223743188,12.8633525413",
     "geom:latitude":12.633344,
     "geom:longitude":-15.512406,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"SN.SD.GP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311864,
-    "wof:geomhash":"8cb6b3e835d4563dff9124b57f0df4e3",
+    "wof:geomhash":"6eece0bb6a5367c2cf50cf0dcaa2a119",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108691457,
-    "wof:lastmodified":1566648638,
+    "wof:lastmodified":1695886417,
     "wof:name":"Goudomp",
     "wof:parent_id":85676979,
     "wof:placetype":"county",

--- a/data/110/869/145/9/1108691459.geojson
+++ b/data/110/869/145/9/1108691459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.228875,
-    "geom:area_square_m":2759673671.206129,
+    "geom:area_square_m":2759673444.394646,
     "geom:bbox":"-16.023499,12.5388,-15.112183,13.05011",
     "geom:latitude":12.807065,
     "geom:longitude":-15.616475,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.SD.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311865,
-    "wof:geomhash":"a7b0577cf46af901b1b29e3cf8c8e59f",
+    "wof:geomhash":"375561f67546626b1b6172b775d24c1d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691459,
-    "wof:lastmodified":1627522783,
+    "wof:lastmodified":1695886477,
     "wof:name":"Sedhiou",
     "wof:parent_id":85676979,
     "wof:placetype":"county",

--- a/data/110/869/146/1/1108691461.geojson
+++ b/data/110/869/146/1/1108691461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.29798,
-    "geom:area_square_m":3592222499.34995,
+    "geom:area_square_m":3592222468.145953,
     "geom:bbox":"-15.170898,12.678785,-14.10932,13.062073",
     "geom:latitude":12.854916,
     "geom:longitude":-14.656132,
@@ -137,9 +137,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KO.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311866,
-    "wof:geomhash":"10a14777d8fa84acd4c28abc6ecfa0b9",
+    "wof:geomhash":"731690590a7dc03a606ec5616e103178",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108691461,
-    "wof:lastmodified":1636495462,
+    "wof:lastmodified":1695886654,
     "wof:name":"Kolda",
     "wof:parent_id":85677027,
     "wof:placetype":"county",

--- a/data/110/869/146/3/1108691463.geojson
+++ b/data/110/869/146/3/1108691463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.588069,
-    "geom:area_square_m":7091841582.787507,
+    "geom:area_square_m":7091840413.649552,
     "geom:bbox":"-13.239067,12.307766,-11.721802,13.209617",
     "geom:latitude":12.76514,
     "geom:longitude":-12.434818,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KG.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311868,
-    "wof:geomhash":"b8d075beb648d97b02238a46d5f627ad",
+    "wof:geomhash":"e504bde7d55ae4c21ac151c17cc63799",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691463,
-    "wof:lastmodified":1627522782,
+    "wof:lastmodified":1695886476,
     "wof:name":"Kedougou",
     "wof:parent_id":85676983,
     "wof:placetype":"county",

--- a/data/110/869/146/5/1108691465.geojson
+++ b/data/110/869/146/5/1108691465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238619,
-    "geom:area_square_m":2873366010.580666,
+    "geom:area_square_m":2873366010.58068,
     "geom:bbox":"-15.9943847656,12.8837280273,-15.225402832,13.3952860788",
     "geom:latitude":13.134858,
     "geom:longitude":-15.603471,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"SN.SD.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311869,
-    "wof:geomhash":"5da9263dc5a80a0c6d435adada477c93",
+    "wof:geomhash":"4778a67e06d964dc4117993c159e47c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108691465,
-    "wof:lastmodified":1566648640,
+    "wof:lastmodified":1695886418,
     "wof:name":"Bounkiling",
     "wof:parent_id":85676979,
     "wof:placetype":"county",

--- a/data/110/869/146/7/1108691467.geojson
+++ b/data/110/869/146/7/1108691467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.65067,
-    "geom:area_square_m":7840206170.307306,
+    "geom:area_square_m":7840207386.694365,
     "geom:bbox":"-12.494507,12.386049,-11.348006,13.461121",
     "geom:latitude":12.973248,
     "geom:longitude":-11.834302,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KG.SY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311870,
-    "wof:geomhash":"193ea7c297cdb7a54ad6fb9f6f734554",
+    "wof:geomhash":"19066f46ae59932f4f5f65a457c891a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108691467,
-    "wof:lastmodified":1627522783,
+    "wof:lastmodified":1695886478,
     "wof:name":"Saraya",
     "wof:parent_id":85676983,
     "wof:placetype":"county",

--- a/data/110/869/147/1/1108691471.geojson
+++ b/data/110/869/147/1/1108691471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.453596,
-    "geom:area_square_m":5465292022.030227,
+    "geom:area_square_m":5465292295.620299,
     "geom:bbox":"-14.349915,12.674477,-13.450989,13.547302",
     "geom:latitude":12.98785,
     "geom:longitude":-13.878602,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KO.VL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311871,
-    "wof:geomhash":"7450db8a1100dfe6c898efd0fd570a0d",
+    "wof:geomhash":"c089079a223cca571437c3d4bdc48289",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691471,
-    "wof:lastmodified":1627522783,
+    "wof:lastmodified":1695886478,
     "wof:name":"Velingara",
     "wof:parent_id":85677027,
     "wof:placetype":"county",

--- a/data/110/869/147/3/1108691473.geojson
+++ b/data/110/869/147/3/1108691473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.392422,
-    "geom:area_square_m":4723877518.812633,
+    "geom:area_square_m":4723877113.860722,
     "geom:bbox":"-15.355713,12.868897,-14.307301,13.600463",
     "geom:latitude":13.214512,
     "geom:longitude":-14.866529,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KO.YF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311872,
-    "wof:geomhash":"f752e13a3b52bc5cf2ee1d34a434585c",
+    "wof:geomhash":"bf6d17479ea4f26bf362855a1a7eb450",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691473,
-    "wof:lastmodified":1627522783,
+    "wof:lastmodified":1695886478,
     "wof:name":"Medina Yoro Foulah",
     "wof:parent_id":85677027,
     "wof:placetype":"county",

--- a/data/110/869/147/5/1108691475.geojson
+++ b/data/110/869/147/5/1108691475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.192207,
-    "geom:area_square_m":2308722137.584415,
+    "geom:area_square_m":2308722137.584459,
     "geom:bbox":"-16.2515869141,13.5917415671,-15.4144001888,13.9120862158",
     "geom:latitude":13.733591,
     "geom:longitude":-15.834987,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KC.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311873,
-    "wof:geomhash":"c3de1cd3cc93d8c34081ce0be2ebf7b0",
+    "wof:geomhash":"2d2b9e9b92dd6191874b59c6f40e5365",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108691475,
-    "wof:lastmodified":1566648642,
+    "wof:lastmodified":1695886418,
     "wof:name":"Nioro du Rip",
     "wof:parent_id":85677011,
     "wof:placetype":"county",

--- a/data/110/869/147/7/1108691477.geojson
+++ b/data/110/869/147/7/1108691477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096295,
-    "geom:area_square_m":1155065091.615866,
+    "geom:area_square_m":1155065392.694665,
     "geom:bbox":"-15.862915,13.774719,-15.477277,14.296692",
     "geom:latitude":14.052826,
     "geom:longitude":-15.684592,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KF.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311875,
-    "wof:geomhash":"fc7f1f850c8d967853333e4cacc27b0d",
+    "wof:geomhash":"8dc1d042246e3e1542ef7290564817fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108691477,
-    "wof:lastmodified":1627522782,
+    "wof:lastmodified":1695886476,
     "wof:name":"Birkelane",
     "wof:parent_id":85676989,
     "wof:placetype":"county",

--- a/data/110/869/147/9/1108691479.geojson
+++ b/data/110/869/147/9/1108691479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090597,
-    "geom:area_square_m":1085612555.347656,
+    "geom:area_square_m":1085612802.019529,
     "geom:bbox":"-16.134277,14.107727,-15.688416,14.498108",
     "geom:latitude":14.284031,
     "geom:longitude":-15.916876,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KC.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311877,
-    "wof:geomhash":"7c4cdc5ef81a3436afaca77105f9acd6",
+    "wof:geomhash":"63b7d22e94b5ad8154be9d16e29a5b59",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691479,
-    "wof:lastmodified":1627522782,
+    "wof:lastmodified":1695886476,
     "wof:name":"Guinguineo",
     "wof:parent_id":85677011,
     "wof:placetype":"county",

--- a/data/110/869/148/1/1108691481.geojson
+++ b/data/110/869/148/1/1108691481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.222753,
-    "geom:area_square_m":2671028092.823075,
+    "geom:area_square_m":2671027652.261209,
     "geom:bbox":"-15.699585,13.74317,-15.104004,14.582182",
     "geom:latitude":14.129529,
     "geom:longitude":-15.44698,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KF.KF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311878,
-    "wof:geomhash":"06131bec397096c57c130b40f24a162d",
+    "wof:geomhash":"6658cc53790dfe1205f259b8ed6c82d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108691481,
-    "wof:lastmodified":1636495461,
+    "wof:lastmodified":1695886654,
     "wof:name":"Kaffrine",
     "wof:parent_id":85676989,
     "wof:placetype":"county",

--- a/data/110/869/148/3/1108691483.geojson
+++ b/data/110/869/148/3/1108691483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.576633,
-    "geom:area_square_m":6914309462.780785,
+    "geom:area_square_m":6914309462.7808,
     "geom:bbox":"-14.8335949535,13.5092778692,-13.7797851563,14.6586914063",
     "geom:latitude":14.132361,
     "geom:longitude":-14.339004,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"SN.TB.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311880,
-    "wof:geomhash":"89247d03da5a9301adaf75b30107d24c",
+    "wof:geomhash":"414eaf324b0660bff116b0c3171a623d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108691483,
-    "wof:lastmodified":1566648639,
+    "wof:lastmodified":1695886417,
     "wof:name":"Koumpentoum",
     "wof:parent_id":85677035,
     "wof:placetype":"county",

--- a/data/110/869/148/5/1108691485.geojson
+++ b/data/110/869/148/5/1108691485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.310007,
-    "geom:area_square_m":15717257280.671246,
+    "geom:area_square_m":15717257280.671366,
     "geom:bbox":"-13.7054252921,13.2366943359,-12.2218017578,14.7084960937",
     "geom:latitude":13.997083,
     "geom:longitude":-12.929176,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"SN.TB.GY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311882,
-    "wof:geomhash":"cb5cc45a5e1696a3645490318d9afccb",
+    "wof:geomhash":"d267623cf83ba56b4cad3972833ee1d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108691485,
-    "wof:lastmodified":1566648639,
+    "wof:lastmodified":1695886417,
     "wof:name":"Goudiry",
     "wof:parent_id":85677035,
     "wof:placetype":"county",

--- a/data/110/869/148/9/1108691489.geojson
+++ b/data/110/869/148/9/1108691489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.226059,
-    "geom:area_square_m":2707966036.299487,
+    "geom:area_square_m":2707966036.29956,
     "geom:bbox":"-15.4684005361,13.993693845,-15.0238037109,14.7233276367",
     "geom:latitude":14.356226,
     "geom:longitude":-15.251061,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"SN.KF.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311883,
-    "wof:geomhash":"49b775ec597938589968eaf1a51f3dd8",
+    "wof:geomhash":"19a009a1dc3e8f76bd81164bfb5b907c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108691489,
-    "wof:lastmodified":1566648638,
+    "wof:lastmodified":1695886417,
     "wof:name":"Malem Hodar",
     "wof:parent_id":85676989,
     "wof:placetype":"county",

--- a/data/110/869/149/1/1108691491.geojson
+++ b/data/110/869/149/1/1108691491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121908,
-    "geom:area_square_m":1459213674.350005,
+    "geom:area_square_m":1459213674.349968,
     "geom:bbox":"-16.2239668945,14.3642827901,-15.4622192383,14.7525024414",
     "geom:latitude":14.52868,
     "geom:longitude":-15.837994,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"SN.FK.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311884,
-    "wof:geomhash":"a49872bf9863757e6906b5b2119aec6e",
+    "wof:geomhash":"21da434b53c47b66c9b292d78aee5b1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108691491,
-    "wof:lastmodified":1566648643,
+    "wof:lastmodified":1695886418,
     "wof:name":"Gossas",
     "wof:parent_id":85677007,
     "wof:placetype":"county",

--- a/data/110/869/149/3/1108691493.geojson
+++ b/data/110/869/149/3/1108691493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108135,
-    "geom:area_square_m":1292930358.263922,
+    "geom:area_square_m":1292930123.710585,
     "geom:bbox":"-16.385914,14.54133,-16.038585,15.02269",
     "geom:latitude":14.768219,
     "geom:longitude":-16.217617,
@@ -149,9 +149,10 @@
     "wof:concordances":{
         "hasc:id":"SN.DB.DB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311889,
-    "wof:geomhash":"60f51f21af5c1710e1581d36b24461f4",
+    "wof:geomhash":"e091f9218524c8a9621ded700951fef5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1108691493,
-    "wof:lastmodified":1636495462,
+    "wof:lastmodified":1695886654,
     "wof:name":"Diourbel",
     "wof:parent_id":85677001,
     "wof:placetype":"county",

--- a/data/110/869/149/5/1108691495.geojson
+++ b/data/110/869/149/5/1108691495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112045,
-    "geom:area_square_m":1339469400.837703,
+    "geom:area_square_m":1339469400.837785,
     "geom:bbox":"-16.687115059,14.5929794197,-16.2831100863,15.0270862567",
     "geom:latitude":14.802769,
     "geom:longitude":-16.483925,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"SN.DB.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311890,
-    "wof:geomhash":"4d6b10beb4c28aa80341384fad51e9e4",
+    "wof:geomhash":"3ac81377688d30874f2598b40b1ea43f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108691495,
-    "wof:lastmodified":1566648643,
+    "wof:lastmodified":1695886418,
     "wof:name":"Bambey",
     "wof:parent_id":85677001,
     "wof:placetype":"county",

--- a/data/110/869/149/7/1108691497.geojson
+++ b/data/110/869/149/7/1108691497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.556915,
-    "geom:area_square_m":6676809117.914646,
+    "geom:area_square_m":6676809117.914924,
     "geom:bbox":"-12.6862801449,13.3112792969,-11.8641775602,15.1002807617",
     "geom:latitude":14.163908,
     "geom:longitude":-12.253499,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"SN.TB.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311891,
-    "wof:geomhash":"6e6005018510e46c3f16066c21335251",
+    "wof:geomhash":"4e8dca4290b64ecc53ae26dfef50e2ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108691497,
-    "wof:lastmodified":1566648642,
+    "wof:lastmodified":1695886418,
     "wof:name":"Bakel",
     "wof:parent_id":85677035,
     "wof:placetype":"county",

--- a/data/110/869/149/9/1108691499.geojson
+++ b/data/110/869/149/9/1108691499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.259339,
-    "geom:area_square_m":3096215817.719921,
+    "geom:area_square_m":3096215817.719817,
     "geom:bbox":"-17.1090131418,14.8112792969,-16.1762084961,15.3602905273",
     "geom:latitude":15.088534,
     "geom:longitude":-16.651812,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"SN.TH.TV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311892,
-    "wof:geomhash":"03662ed96fa18b0f442916301898449e",
+    "wof:geomhash":"036aba9b9c004ff5c75ed653a8a6db21",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108691499,
-    "wof:lastmodified":1566648642,
+    "wof:lastmodified":1695886418,
     "wof:name":"Tivaouane",
     "wof:parent_id":85677025,
     "wof:placetype":"county",

--- a/data/110/869/150/1/1108691501.geojson
+++ b/data/110/869/150/1/1108691501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.724641,
-    "geom:area_square_m":8656046323.877672,
+    "geom:area_square_m":8656046323.877758,
     "geom:bbox":"-13.6728222881,14.4064941406,-12.5869750977,15.606845486",
     "geom:latitude":14.972392,
     "geom:longitude":-13.131215,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"SN.MT.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311893,
-    "wof:geomhash":"fd56036cb71f2e5b689e0dbeeff1fdc2",
+    "wof:geomhash":"0f929bceaed1c9c56ba00d8a706f5a4b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108691501,
-    "wof:lastmodified":1566648637,
+    "wof:lastmodified":1695886417,
     "wof:name":"Kanel",
     "wof:parent_id":85677019,
     "wof:placetype":"county",

--- a/data/110/869/150/3/1108691503.geojson
+++ b/data/110/869/150/3/1108691503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.333831,
-    "geom:area_square_m":3981483306.015253,
+    "geom:area_square_m":3981481571.704403,
     "geom:bbox":"-16.809996,14.955078,-15.805603,15.667776",
     "geom:latitude":15.304243,
     "geom:longitude":-16.261161,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.LG.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311894,
-    "wof:geomhash":"29425e38eb79e9a221cb777ec33400d7",
+    "wof:geomhash":"19ae62fd9810adb8dcb9acc88dfecf83",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691503,
-    "wof:lastmodified":1627522782,
+    "wof:lastmodified":1695886477,
     "wof:name":"Kebemer",
     "wof:parent_id":85677015,
     "wof:placetype":"county",

--- a/data/110/869/150/7/1108691507.geojson
+++ b/data/110/869/150/7/1108691507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.211094,
-    "geom:area_square_m":14462727897.131516,
+    "geom:area_square_m":14462728582.558151,
     "geom:bbox":"-14.849304,14.407049,-13.447681,15.805115",
     "geom:latitude":15.032214,
     "geom:longitude":-14.133223,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.MT.RN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311895,
-    "wof:geomhash":"b3765fa7a1e9c394cf89b47e3014b1e5",
+    "wof:geomhash":"234627dbc15f7fab23a6a431778049a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691507,
-    "wof:lastmodified":1627522783,
+    "wof:lastmodified":1695886478,
     "wof:name":"Ranerou",
     "wof:parent_id":85677019,
     "wof:placetype":"county",

--- a/data/110/869/150/9/1108691509.geojson
+++ b/data/110/869/150/9/1108691509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.348336,
-    "geom:area_square_m":16078162586.178257,
+    "geom:area_square_m":16078161840.182814,
     "geom:bbox":"-15.818787,14.612488,-14.496399,16.001099",
     "geom:latitude":15.339568,
     "geom:longitude":-15.178003,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SN.LG.LN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311896,
-    "wof:geomhash":"915ac6d6439ccb210ca8531dca47f18d",
+    "wof:geomhash":"fdc75acca76414bbb617582ad19f1c53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691509,
-    "wof:lastmodified":1627522782,
+    "wof:lastmodified":1695886477,
     "wof:name":"Linguere",
     "wof:parent_id":85677015,
     "wof:placetype":"county",

--- a/data/110/869/151/1/1108691511.geojson
+++ b/data/110/869/151/1/1108691511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067786,
-    "geom:area_square_m":805877491.650319,
+    "geom:area_square_m":805877697.430867,
     "geom:bbox":"-16.525611,15.832969,-16.095395,16.140691",
     "geom:latitude":15.960059,
     "geom:longitude":-16.365532,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"SN.ST.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311897,
-    "wof:geomhash":"9009743319ce74b60cd974e39908c1d7",
+    "wof:geomhash":"42d6943c26e52ff576f5eb350b451fbe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108691511,
-    "wof:lastmodified":1636495461,
+    "wof:lastmodified":1695886654,
     "wof:name":"Saint-Louis",
     "wof:parent_id":85676993,
     "wof:placetype":"county",

--- a/data/110/869/151/3/1108691513.geojson
+++ b/data/110/869/151/3/1108691513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.478181,
-    "geom:area_square_m":5691008144.55442,
+    "geom:area_square_m":5691008396.92193,
     "geom:bbox":"-16.591877,15.364362,-15.580612,16.187463",
     "geom:latitude":15.741582,
     "geom:longitude":-16.001487,
@@ -146,9 +146,10 @@
     "wof:concordances":{
         "hasc:id":"SN.LG.LG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311899,
-    "wof:geomhash":"abcbff2d6373ef1800328bee86350b54",
+    "wof:geomhash":"116157cd8684e81c49363c1a0911a2ed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108691513,
-    "wof:lastmodified":1636495461,
+    "wof:lastmodified":1695886654,
     "wof:name":"Louga",
     "wof:parent_id":85677015,
     "wof:placetype":"county",

--- a/data/110/869/151/5/1108691515.geojson
+++ b/data/110/869/151/5/1108691515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.102905,
-    "geom:area_square_m":13096141739.085443,
+    "geom:area_square_m":13096141739.085543,
     "geom:bbox":"-15.4387817383,15.4939880371,-13.6975097656,16.6917114258",
     "geom:latitude":16.198044,
     "geom:longitude":-14.605628,
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"SN.ST.PD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1474311901,
-    "wof:geomhash":"3b6dfbe9c76a9ed27c0f74c1104e5ee0",
+    "wof:geomhash":"1f3bce913eb68ea739a83916d8b5c9d6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108691515,
-    "wof:lastmodified":1566648637,
+    "wof:lastmodified":1695886417,
     "wof:name":"Podor",
     "wof:parent_id":85676993,
     "wof:placetype":"county",

--- a/data/421/166/855/421166855.geojson
+++ b/data/421/166/855/421166855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.379993,
-    "geom:area_square_m":4554983645.205395,
+    "geom:area_square_m":4554983645.205382,
     "geom:bbox":"-15.145385828,13.7694944943,-14.5825974837,14.7036743164",
     "geom:latitude":14.204736,
     "geom:longitude":-14.858494,
@@ -108,12 +108,13 @@
         "hasc:id":"SN.KF.KU",
         "qs_pg:id":483153
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459008705,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"edf02d16a875091219fe41ea68fe7d48",
+    "wof:geomhash":"a469463796a4ddc07db410ded1b5ffbb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421166855,
-    "wof:lastmodified":1582317844,
+    "wof:lastmodified":1695886587,
     "wof:name":"Koungheul",
     "wof:parent_id":85676989,
     "wof:placetype":"county",

--- a/data/421/176/669/421176669.geojson
+++ b/data/421/176/669/421176669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187964,
-    "geom:area_square_m":2247383021.07517,
+    "geom:area_square_m":2247382906.191351,
     "geom:bbox":"-16.11607,14.514526,-15.436279,14.997681",
     "geom:latitude":14.772593,
     "geom:longitude":-15.833084,
@@ -94,12 +94,13 @@
         "hasc:id":"SN.DB.MK",
         "qs_pg:id":1063170
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009115,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0bd28fbd680bb0997fc979e5d605ae5f",
+    "wof:geomhash":"0f51d2e2d8099e461f7fd7a279703faf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421176669,
-    "wof:lastmodified":1627522783,
+    "wof:lastmodified":1695886477,
     "wof:name":"Mbacke",
     "wof:parent_id":85677001,
     "wof:placetype":"county",

--- a/data/421/181/825/421181825.geojson
+++ b/data/421/181/825/421181825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157549,
-    "geom:area_square_m":1889702855.823881,
+    "geom:area_square_m":1889702977.827646,
     "geom:bbox":"-16.388183,13.853565,-15.683777,14.370173",
     "geom:latitude":14.067271,
     "geom:longitude":-16.067016,
@@ -189,12 +189,13 @@
         "hasc:id":"SN.KC.KL",
         "qs_pg:id":505878
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009308,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"321be15d91aac6e0cd9f7740c6947e0f",
+    "wof:geomhash":"941f0c663161a3d487ead926ba1f1349",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421181825,
-    "wof:lastmodified":1636495466,
+    "wof:lastmodified":1695886655,
     "wof:name":"Kaolack",
     "wof:parent_id":85677011,
     "wof:placetype":"county",

--- a/data/421/185/475/421185475.geojson
+++ b/data/421/185/475/421185475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15911,
-    "geom:area_square_m":1905112079.730402,
+    "geom:area_square_m":1905111646.01809,
     "geom:bbox":"-17.144621,14.05389,-16.518716,14.68988",
     "geom:latitude":14.458964,
     "geom:longitude":-16.830766,
@@ -93,12 +93,13 @@
         "hasc:id":"SN.TH.MR",
         "qs_pg:id":896713
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009444,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e96c373b90a885b073d8c9c628a05fc",
+    "wof:geomhash":"3ee3b9a8ec5a85756c1554b1b9ed0fa0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421185475,
-    "wof:lastmodified":1627522783,
+    "wof:lastmodified":1695886477,
     "wof:name":"Mbour",
     "wof:parent_id":85677025,
     "wof:placetype":"county",

--- a/data/421/187/935/421187935.geojson
+++ b/data/421/187/935/421187935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.220342,
-    "geom:area_square_m":2639950284.848679,
+    "geom:area_square_m":2639949568.912514,
     "geom:bbox":"-16.793096,13.832192,-16.089733,14.607616",
     "geom:latitude":14.316852,
     "geom:longitude":-16.490357,
@@ -237,12 +237,13 @@
         "qs_pg:id":9377,
         "wd:id":"Q430470"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009528,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa8a13869af2330fde5552168c80e269",
+    "wof:geomhash":"4dd72e11fc97a766439a2b42a5edf949",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -252,7 +253,7 @@
         }
     ],
     "wof:id":421187935,
-    "wof:lastmodified":1690865883,
+    "wof:lastmodified":1695886655,
     "wof:name":"Fatick",
     "wof:parent_id":85677007,
     "wof:placetype":"county",

--- a/data/421/187/963/421187963.geojson
+++ b/data/421/187/963/421187963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0312,
-    "geom:area_square_m":373056796.499505,
+    "geom:area_square_m":373056799.844748,
     "geom:bbox":"-17.328999,14.586814,-17.126221,14.88634",
     "geom:latitude":14.760713,
     "geom:longitude":-17.208443,
@@ -122,12 +122,13 @@
         "wd:id":"Q2067770",
         "wk:page":"Rufisque Department"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8aa9d7a8900c96faecb6651f54201fb9",
+    "wof:geomhash":"04cbb51712edd756dc6f45d4f28470c4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421187963,
-    "wof:lastmodified":1690865883,
+    "wof:lastmodified":1695886587,
     "wof:name":"Rufisque",
     "wof:parent_id":85676997,
     "wof:placetype":"county",

--- a/data/421/187/969/421187969.geojson
+++ b/data/421/187/969/421187969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.24769,
-    "geom:area_square_m":2973680445.20485,
+    "geom:area_square_m":2973685207.953125,
     "geom:bbox":"-16.754634,13.586571,-16.08551,14.170282",
     "geom:latitude":13.84908,
     "geom:longitude":-16.427083,
@@ -93,12 +93,13 @@
         "hasc:id":"SN.FK.FD",
         "qs_pg:id":1086870
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c59177eedfdba3dab4e0d4686ef93f6",
+    "wof:geomhash":"7a25876ad83b8ea7749cc56be811d0c0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421187969,
-    "wof:lastmodified":1627522782,
+    "wof:lastmodified":1695886475,
     "wof:name":"Foundiougne",
     "wof:parent_id":85677007,
     "wof:placetype":"county",

--- a/data/421/187/971/421187971.geojson
+++ b/data/421/187/971/421187971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074025,
-    "geom:area_square_m":893719470.963628,
+    "geom:area_square_m":893719470.963593,
     "geom:bbox":"-16.7939990746,12.337969219,-16.4352658349,12.6506957994",
     "geom:latitude":12.475579,
     "geom:longitude":-16.616051,
@@ -117,12 +117,13 @@
         "hasc:id":"SN.ZG.OU",
         "qs_pg:id":1086871
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e2d66c30e14e75372e4a7a3884862488",
+    "wof:geomhash":"e187bc5c4324f8d0a9a3949b3e927468",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421187971,
-    "wof:lastmodified":1582317844,
+    "wof:lastmodified":1695886587,
     "wof:name":"Oussouye",
     "wof:parent_id":85677033,
     "wof:placetype":"county",

--- a/data/421/187/973/421187973.geojson
+++ b/data/421/187/973/421187973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.44666,
-    "geom:area_square_m":5301562722.608241,
+    "geom:area_square_m":5301562620.611628,
     "geom:bbox":"-16.491601,15.926856,-15.333984,16.59668",
     "geom:latitude":16.280167,
     "geom:longitude":-15.87763,
@@ -122,12 +122,13 @@
         "wd:id":"Q3044632",
         "wk:page":"Dagana Department, Senegal"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"43892d51647d2badc4b27b0dbbfa4bbb",
+    "wof:geomhash":"038eb28344a60e020c16d76bbf1d08b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421187973,
-    "wof:lastmodified":1690865883,
+    "wof:lastmodified":1695886588,
     "wof:name":"Dagana",
     "wof:parent_id":85676993,
     "wof:placetype":"county",

--- a/data/421/191/947/421191947.geojson
+++ b/data/421/191/947/421191947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.116805,
-    "geom:area_square_m":13428215660.457708,
+    "geom:area_square_m":13428215036.924694,
     "geom:bbox":"-14.430785,12.629939,-12.461182,14.412476",
     "geom:latitude":13.489376,
     "geom:longitude":-13.472529,
@@ -131,12 +131,13 @@
         "wd:id":"Q2086236",
         "wk:page":"Tambacounda Department"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009715,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d441da09d95db8a636dbc0b312aef17c",
+    "wof:geomhash":"be4b20dca93b1cb6abf5d17e1ff95380",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421191947,
-    "wof:lastmodified":1690865885,
+    "wof:lastmodified":1695886655,
     "wof:name":"Tambacounda",
     "wof:parent_id":85677035,
     "wof:placetype":"county",

--- a/data/421/193/105/421193105.geojson
+++ b/data/421/193/105/421193105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00652,
-    "geom:area_square_m":77955603.066255,
+    "geom:area_square_m":77955483.344175,
     "geom:bbox":"-17.424805,14.717855,-17.297578,14.8143",
     "geom:latitude":14.76233,
     "geom:longitude":-17.348734,
@@ -120,12 +120,13 @@
         "wd:id":"Q255486",
         "wk:page":"Pikine Department"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459009760,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d09a51996407ac06f31773c97b976b0",
+    "wof:geomhash":"6f9bd2699457424d8b7cb732396d4e8e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421193105,
-    "wof:lastmodified":1690865880,
+    "wof:lastmodified":1695886477,
     "wof:name":"Pikine",
     "wof:parent_id":85676997,
     "wof:placetype":"county",

--- a/data/421/203/235/421203235.geojson
+++ b/data/421/203/235/421203235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.443381,
-    "geom:area_square_m":5344358130.46489,
+    "geom:area_square_m":5344358130.464957,
     "geom:bbox":"-16.7870907287,12.5543213005,-15.8939819336,13.1704465744",
     "geom:latitude":12.887631,
     "geom:longitude":-16.366679,
@@ -117,12 +117,13 @@
         "hasc:id":"SN.ZG.BG",
         "qs_pg:id":230301
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"35ca5de8a807060174d3299e19d24a36",
+    "wof:geomhash":"def880ab75fc8f3fa697d95668dbe4f1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421203235,
-    "wof:lastmodified":1582317844,
+    "wof:lastmodified":1695886588,
     "wof:name":"Bignona",
     "wof:parent_id":85677033,
     "wof:placetype":"county",

--- a/data/421/203/237/421203237.geojson
+++ b/data/421/203/237/421203237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094956,
-    "geom:area_square_m":1146242618.605588,
+    "geom:area_square_m":1146242463.948187,
     "geom:bbox":"-16.537487,12.362231,-15.888443,12.658875",
     "geom:latitude":12.517766,
     "geom:longitude":-16.223011,
@@ -158,12 +158,13 @@
         "wd:id":"Q2087556",
         "wk:page":"Ziguinchor Department"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"317f765dcbf9dcfb412a7c1325af9fc3",
+    "wof:geomhash":"8cd84fd00aa6f1b2f00e1b0dcf824522",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421203237,
-    "wof:lastmodified":1690865882,
+    "wof:lastmodified":1695886654,
     "wof:name":"Ziguinchor",
     "wof:parent_id":85677033,
     "wof:placetype":"county",

--- a/data/421/203/459/421203459.geojson
+++ b/data/421/203/459/421203459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13489,
-    "geom:area_square_m":1613007536.077451,
+    "geom:area_square_m":1613007536.0774,
     "geom:bbox":"-17.1767567751,14.5076904297,-16.6044058394,14.952827122",
     "geom:latitude":14.745971,
     "geom:longitude":-16.869967,
@@ -118,12 +118,13 @@
         "hasc:id":"SN.TH.TH",
         "qs_pg:id":231635
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1459010152,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3698dd3b9e770af152b69d85768b987b",
+    "wof:geomhash":"820a7b97783e2b022f1423b5b674272e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421203459,
-    "wof:lastmodified":1582317844,
+    "wof:lastmodified":1695886588,
     "wof:name":"Thies",
     "wof:parent_id":85677025,
     "wof:placetype":"county",

--- a/data/856/323/65/85632365.geojson
+++ b/data/856/323/65/85632365.geojson
@@ -1131,6 +1131,7 @@
         "hasc:id":"SN",
         "icao:code":"6V",
         "ioc:id":"SEN",
+        "iso:code":"SN",
         "itu:id":"SEN",
         "loc:id":"n79007506",
         "m49:code":"686",
@@ -1145,6 +1146,7 @@
         "wk:page":"Senegal",
         "wmo:id":"SG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:country_alpha3":"SEN",
     "wof:geom_alt":[
@@ -1168,7 +1170,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1694639508,
+    "wof:lastmodified":1695881162,
     "wof:name":"Senegal",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/769/79/85676979.geojson
+++ b/data/856/769/79/85676979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.611913,
-    "geom:area_square_m":7375568804.478768,
+    "geom:area_square_m":7375569068.972914,
     "geom:bbox":"-16.023499,12.424905,-15.112183,13.395286",
     "geom:latitude":12.893889,
     "geom:longitude":-15.586843,
@@ -230,17 +230,19 @@
         "gn:id":2249781,
         "gp:id":2346996,
         "hasc:id":"SN.SD",
+        "iso:code":"SN-SE",
         "iso:id":"SN-SE",
         "qs_pg:id":894990,
         "unlc:id":"SN-SE",
         "wd:id":"Q738081",
         "wk:page":"S\u00e9dhiou Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"92b2f4b85564ab96a32ded6eef1905c1",
+    "wof:geomhash":"f9bc9fc1d2175dc305bccab711adaafc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -257,7 +259,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865875,
+    "wof:lastmodified":1695884338,
     "wof:name":"Sedhiou",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/769/83/85676983.geojson
+++ b/data/856/769/83/85676983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.398205,
-    "geom:area_square_m":16856364222.772202,
+    "geom:area_square_m":16856364223.201145,
     "geom:bbox":"-13.239067,12.307766,-11.348006,13.461121",
     "geom:latitude":12.843309,
     "geom:longitude":-12.196767,
@@ -237,17 +237,19 @@
         "gn:id":7303936,
         "gp:id":56055613,
         "hasc:id":"SN.KG",
+        "iso:code":"SN-KE",
         "iso:id":"SN-KE",
         "qs_pg:id":1206083,
         "unlc:id":"SN-KE",
         "wd:id":"Q1046666",
         "wk:page":"K\u00e9dougou Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e1b8fa9f79fbaa9222e679261aaa1d4",
+    "wof:geomhash":"d4944a32560bd2e61ded555fcb0dd052",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -264,7 +266,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865875,
+    "wof:lastmodified":1695884338,
     "wof:name":"Kedougou",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/769/89/85676989.geojson
+++ b/data/856/769/89/85676989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.925099,
-    "geom:area_square_m":11089042865.943865,
+    "geom:area_square_m":11089042795.222706,
     "geom:bbox":"-15.862915,13.74317,-14.582597,14.723328",
     "geom:latitude":14.207833,
     "geom:longitude":-15.182113,
@@ -238,17 +238,19 @@
         "gn:id":7303935,
         "gp:id":56055612,
         "hasc:id":"SN.KF",
+        "iso:code":"SN-KA",
         "iso:id":"SN-KA",
         "qs_pg:id":230300,
         "unlc:id":"SN-KA",
         "wd:id":"Q1059694",
         "wk:page":"Kaffrine Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d9172cc08dd0e4fbf096d3d8913d80a",
+    "wof:geomhash":"0ada34519a3fd5318d1ef76763a6e44f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -265,7 +267,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865874,
+    "wof:lastmodified":1695884795,
     "wof:name":"Kaffrine",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/769/93/85676993.geojson
+++ b/data/856/769/93/85676993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.617351,
-    "geom:area_square_m":19203581953.343708,
+    "geom:area_square_m":19203582466.28178,
     "geom:bbox":"-16.525611,15.493988,-13.69751,16.691711",
     "geom:latitude":16.210749,
     "geom:longitude":-15.030674,
@@ -238,16 +238,18 @@
         "gn:id":2246451,
         "gp:id":2346990,
         "hasc:id":"SN.ST",
+        "iso:code":"SN-SL",
         "iso:id":"SN-SL",
         "qs_pg:id":318818,
         "wd:id":"Q178872",
         "wk:page":"Saint-Louis Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02eff0c54ac981c6fa43b3833c25d759",
+    "wof:geomhash":"ee2fb1d004cef130d834c1a7ab2ab0bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -264,7 +266,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865874,
+    "wof:lastmodified":1695884795,
     "wof:name":"Saint-Louis",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/769/97/85676997.geojson
+++ b/data/856/769/97/85676997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045757,
-    "geom:area_square_m":547131196.432903,
+    "geom:area_square_m":547131070.660593,
     "geom:bbox":"-17.530916,14.586814,-17.126221,14.88634",
     "geom:latitude":14.755572,
     "geom:longitude":-17.271206,
@@ -306,17 +306,19 @@
         "gn:id":2253350,
         "gp:id":2346988,
         "hasc:id":"SN.DK",
+        "iso:code":"SN-DK",
         "iso:id":"SN-DK",
         "qs_pg:id":191398,
         "unlc:id":"SN-DK",
         "wd:id":"Q856268",
         "wk:page":"Dakar Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6e47525eac69b6821a82ed7257d2a78b",
+    "wof:geomhash":"c92dfa567b9629cf5386a1c5a84beefb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865875,
+    "wof:lastmodified":1695885134,
     "wof:name":"Dakar",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/01/85677001.geojson
+++ b/data/856/770/01/85677001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.408143,
-    "geom:area_square_m":4879782815.958377,
+    "geom:area_square_m":4879782815.95837,
     "geom:bbox":"-16.687115,14.514526,-15.436279,15.027086",
     "geom:latitude":14.779718,
     "geom:longitude":-16.113634,
@@ -296,17 +296,19 @@
         "gn:id":2252308,
         "gp:id":2346989,
         "hasc:id":"SN.DB",
+        "iso:code":"SN-DB",
         "iso:id":"SN-DB",
         "qs_pg:id":1142839,
         "unlc:id":"SN-DB ",
         "wd:id":"Q856261",
         "wk:page":"Diourbel Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f70426eb5c0ad24b9c82bf4d97867adf",
+    "wof:geomhash":"cd447d07183a6ff6eadde8249c1e71f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865873,
+    "wof:lastmodified":1695884794,
     "wof:name":"Diourbel",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/07/85677007.geojson
+++ b/data/856/770/07/85677007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.58994,
-    "geom:area_square_m":7072844404.402997,
+    "geom:area_square_m":7072848240.50608,
     "geom:bbox":"-16.793096,13.586571,-15.462219,14.752502",
     "geom:latitude":14.164229,
     "geom:longitude":-16.328983,
@@ -292,17 +292,19 @@
         "gn:id":2251910,
         "gp:id":2346994,
         "hasc:id":"SN.FK",
+        "iso:code":"SN-FK",
         "iso:id":"SN-FK",
         "qs_pg:id":219614,
         "unlc:id":"SN-FK",
         "wd:id":"Q856282",
         "wk:page":"Fatick Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f10e42ee5c50b73d516097115f6cff92",
+    "wof:geomhash":"3bd9c67eb5487d9334ef2d69714f6f99",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865873,
+    "wof:lastmodified":1695885133,
     "wof:name":"Fatick",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/11/85677011.geojson
+++ b/data/856/770/11/85677011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.440353,
-    "geom:area_square_m":5284037548.75616,
+    "geom:area_square_m":5284037293.351603,
     "geom:bbox":"-16.388183,13.591742,-15.4144,14.498108",
     "geom:latitude":13.966221,
     "geom:longitude":-15.93485,
@@ -228,16 +228,18 @@
         "gn:id":2250804,
         "gp:id":2346995,
         "hasc:id":"SN.KC",
+        "iso:code":"SN-KL",
         "iso:id":"SN-KL",
         "qs_pg:id":1083864,
         "wd:id":"Q847671",
         "wk:page":"Kaolack Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d4d450c57875785027b3c0418a3b7ee",
+    "wof:geomhash":"95588d6914ecfa77bd54933b97f70528",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -254,7 +256,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865872,
+    "wof:lastmodified":1695884794,
     "wof:name":"Kaolack",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/15/85677015.geojson
+++ b/data/856/770/15/85677015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.160347,
-    "geom:area_square_m":25750654036.74786,
+    "geom:area_square_m":25750651808.809219,
     "geom:bbox":"-16.809996,14.612488,-14.496399,16.187463",
     "geom:latitude":15.423093,
     "geom:longitude":-15.527653,
@@ -296,17 +296,19 @@
         "gn:id":2249221,
         "gp:id":2346993,
         "hasc:id":"SN.LG",
+        "iso:code":"SN-LG",
         "iso:id":"SN-LG",
         "qs_pg:id":424016,
         "unlc:id":"SN-LG",
         "wd:id":"Q738061",
         "wk:page":"Louga Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"55f9c87830a5d0999ebaf7840251702a",
+    "wof:geomhash":"ca97a9fdec1833b011b02681bc252f36",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865874,
+    "wof:lastmodified":1695884795,
     "wof:name":"Louga",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/19/85677019.geojson
+++ b/data/856/770/19/85677019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.417122,
-    "geom:area_square_m":28848541258.976482,
+    "geom:area_square_m":28848542015.685673,
     "geom:bbox":"-14.849304,14.406494,-12.586975,16.146118",
     "geom:latitude":15.151292,
     "geom:longitude":-13.733212,
@@ -230,17 +230,19 @@
         "gn:id":2248753,
         "gp:id":56055615,
         "hasc:id":"SN.MT",
+        "iso:code":"SN-MT",
         "iso:id":"SN-MT",
         "qs_pg:id":78474,
         "unlc:id":"SN-MT",
         "wd:id":"Q856275",
         "wk:page":"Matam Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"036740e818d2b009cc19dc8fe4e5d296",
+    "wof:geomhash":"bcdd747fddc749cfe5580f8e06fd881a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -257,7 +259,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865873,
+    "wof:lastmodified":1695884794,
     "wof:name":"Matam",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/25/85677025.geojson
+++ b/data/856/770/25/85677025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.55334,
-    "geom:area_square_m":6614335433.527568,
+    "geom:area_square_m":6614336171.011456,
     "geom:bbox":"-17.176757,14.05389,-16.176208,15.360291",
     "geom:latitude":14.823996,
     "geom:longitude":-16.75645,
@@ -289,17 +289,19 @@
         "gn:id":2244800,
         "gp:id":2346992,
         "hasc:id":"SN.TH",
+        "iso:code":"SN-TH",
         "iso:id":"SN-TH",
         "qs_pg:id":235639,
         "unlc:id":"SN-TH",
         "wd:id":"Q847682",
         "wk:page":"Thi\u00e8s Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"084da9d6d057c50757c1bf4a5b1bd884",
+    "wof:geomhash":"9892bb62d8bd79b69b28892742055efa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -316,7 +318,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865874,
+    "wof:lastmodified":1695884338,
     "wof:name":"Thies",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/27/85677027.geojson
+++ b/data/856/770/27/85677027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.143998,
-    "geom:area_square_m":13781392040.192282,
+    "geom:area_square_m":13781391877.626715,
     "geom:bbox":"-15.355713,12.674477,-13.450989,13.600463",
     "geom:latitude":13.030976,
     "geom:longitude":-14.420012,
@@ -246,16 +246,18 @@
         "gn:id":2249781,
         "gp:id":2346996,
         "hasc:id":"SN.KO",
+        "iso:code":"SN-KD",
         "iso:id":"SN-KD",
         "qs_pg:id":894990,
         "wd:id":"Q738081",
         "wk:page":"Kolda Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3dee51f571fca7532d8da6b4d4592d95",
+    "wof:geomhash":"310ea100009f025284a98733c75729b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -272,7 +274,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865872,
+    "wof:lastmodified":1695884794,
     "wof:name":"Kolda",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/33/85677033.geojson
+++ b/data/856/770/33/85677033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.612362,
-    "geom:area_square_m":7384320220.034278,
+    "geom:area_square_m":7384321677.043797,
     "geom:bbox":"-16.793999,12.337969,-15.888443,13.170447",
     "geom:latitude":12.780467,
     "geom:longitude":-16.374546,
@@ -296,17 +296,19 @@
         "gn:id":2243939,
         "gp:id":2346997,
         "hasc:id":"SN.ZG",
+        "iso:code":"SN-ZG",
         "iso:id":"SN-ZG",
         "qs_pg:id":901871,
         "unlc:id":"SN-ZG",
         "wd:id":"Q822692",
         "wk:page":"Ziguinchor Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a1083800d47333623fab5192eec63632",
+    "wof:geomhash":"301adaf8f60b54a2b5ab2a5a9f6899db",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865872,
+    "wof:lastmodified":1695884794,
     "wof:name":"Ziguinchor",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/856/770/35/85677035.geojson
+++ b/data/856/770/35/85677035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.560359,
-    "geom:area_square_m":42736591521.823174,
+    "geom:area_square_m":42736590272.88868,
     "geom:bbox":"-14.833595,12.629939,-11.864178,15.100281",
     "geom:latitude":13.885831,
     "geom:longitude":-13.222258,
@@ -241,16 +241,18 @@
         "gn:id":2244990,
         "gp:id":2346991,
         "hasc:id":"SN.TB",
+        "iso:code":"SN-TC",
         "iso:id":"SN-TC",
         "qs_pg:id":235638,
         "wd:id":"Q848554",
         "wk:page":"Tambacounda Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3664ddde6c71707373e8f3770858325d",
+    "wof:geomhash":"36b37f49ebb2dd6d70969c45d4bac183",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -267,7 +269,7 @@
         "wol",
         "fra"
     ],
-    "wof:lastmodified":1690865871,
+    "wof:lastmodified":1695884794,
     "wof:name":"Tambacounda",
     "wof:parent_id":85632365,
     "wof:placetype":"region",

--- a/data/890/424/907/890424907.geojson
+++ b/data/890/424/907/890424907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.481387,
-    "geom:area_square_m":5729767037.966925,
+    "geom:area_square_m":5729766813.871392,
     "geom:bbox":"-14.248383,15.290649,-13.158889,16.146118",
     "geom:latitude":15.720178,
     "geom:longitude":-13.633046,
@@ -113,12 +113,13 @@
         "wd:id":"Q2085162",
         "wk:page":"Matam Department"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1469051568,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f73b9ac7adebcbe4677b932c1029f51",
+    "wof:geomhash":"d344c93b3f86405f6c7f71ffb3b775f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":890424907,
-    "wof:lastmodified":1690865890,
+    "wof:lastmodified":1695886655,
     "wof:name":"Matam",
     "wof:parent_id":85677019,
     "wof:placetype":"county",

--- a/data/890/440/853/890440853.geojson
+++ b/data/890/440/853/890440853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001134,
-    "geom:area_square_m":13563805.100887,
+    "geom:area_square_m":13563742.29089,
     "geom:bbox":"-17.43042,14.744507,-17.362488,14.79839",
     "geom:latitude":14.77672,
     "geom:longitude":-17.395334,
@@ -224,12 +224,13 @@
         "wd:id":"Q1557691",
         "wk:page":"Gu\u00e9diawaye"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SN",
     "wof:created":1469052299,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"af7c88f6a0c100d8fd2fe44c520faffb",
+    "wof:geomhash":"b48aad281192eccab5c101d7e0a71d81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -239,7 +240,7 @@
         }
     ],
     "wof:id":890440853,
-    "wof:lastmodified":1690865890,
+    "wof:lastmodified":1695886588,
     "wof:name":"Guediewaye",
     "wof:parent_id":85676997,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.